### PR TITLE
feat: add discount and cash handling for sales

### DIFF
--- a/src/stores/transaction.store.ts
+++ b/src/stores/transaction.store.ts
@@ -60,13 +60,23 @@ export const useTransactionStore = create<TransactionState>((set) => ({
     let recordToInsert: any = { type: transactionData.type };
 
     if (transactionData.type === 'sale') {
-        const grandTotal = transactionData.items.reduce((sum, item) => sum + (item.pricePerItem * item.quantity), 0);
+        const subtotal = transactionData.items.reduce((sum, item) => sum + (item.pricePerItem * item.quantity), 0);
+        const discountAmount = transactionData.discountAmount ?? 0;
+        const grandTotal = subtotal - discountAmount;
+        const change = transactionData.cashTendered !== undefined
+          ? (transactionData.cashTendered - grandTotal)
+          : undefined;
         recordToInsert = {
             ...recordToInsert,
             customer_name: transactionData.customerName,
             customer_id: transactionData.customerId,
             payment_method: transactionData.paymentMethod,
             total_amount: grandTotal,
+            discount_type: transactionData.discountType,
+            discount_value: transactionData.discountValue,
+            discount_amount: discountAmount,
+            cash_tendered: transactionData.cashTendered,
+            change,
             details: { items: transactionData.items }
         };
     } else if (transactionData.type === 'service') {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,6 +16,11 @@ export type SaleTransaction = {
   customerName?: string; // This will be used to link to Customer if customerId is not present
   customerId?: string; // Optional: to link to a specific customer in CRM
   grandTotal: number;
+  discountType?: 'percent' | 'nominal';
+  discountValue?: number;
+  discountAmount?: number;
+  cashTendered?: number;
+  change?: number;
 };
 
 export const ServiceStatusOptions = [

--- a/src/utils/mapDBRowToTransaction.ts
+++ b/src/utils/mapDBRowToTransaction.ts
@@ -17,8 +17,13 @@ export function mapDbRowToTransaction(tx: any): Transaction | null {
         ...commonData,
         type: 'sale',
         grandTotal: commonData.total_amount,
-        paymentMethod: details.paymentMethod,
+        paymentMethod: tx.payment_method || details.paymentMethod,
         items: details.items ?? [],
+        discountType: tx.discount_type || details.discountType,
+        discountValue: tx.discount_value || details.discountValue,
+        discountAmount: tx.discount_amount || details.discountAmount,
+        cashTendered: tx.cash_tendered || details.cashTendered,
+        change: tx.change || details.change,
       } as SaleTransaction;
 
     case 'service':

--- a/supabase/migrations/20241017120000_add_discount_cash_fields_to_transactions.sql
+++ b/supabase/migrations/20241017120000_add_discount_cash_fields_to_transactions.sql
@@ -1,0 +1,6 @@
+alter table transactions
+  add column if not exists discount_type text,
+  add column if not exists discount_value numeric,
+  add column if not exists discount_amount numeric,
+  add column if not exists cash_tendered numeric,
+  add column if not exists change numeric;


### PR DESCRIPTION
## Summary
- support discount percent/nominal and cash tendered with change calculation on sales page
- extend transaction types, store, and mapping for discount and cash details
- add migration to store discount and cash fields in transactions table

## Testing
- `npm run lint` *(fails: existing lint errors)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_689d8e2b43a08329ac35ba60663bc670