### PR TITLE
feat: validate sale stock

### DIFF
--- a/src/app/admin/manage-inventory/page.tsx
+++ b/src/app/admin/manage-inventory/page.tsx
@@ -31,7 +31,10 @@ import { RestockDialog } from '@/components/ui/restock-dialog';
 // Zod Schema
 const inventoryItemSchema = z.object({
   name: z.string().min(1, 'Nama barang harus diisi'),
-  sku: z.string().optional(),
+  sku: z
+    .string()
+    .optional()
+    .transform((val) => (val && val.trim() !== '' ? val.trim() : undefined)),
   stockQuantity: z.coerce.number().int().min(0, 'Stok tidak boleh negatif'),
   purchasePrice: z.coerce.number().min(0, 'Harga beli tidak boleh negatif'),
   sellingPrice: z.coerce.number().min(0, 'Harga jual tidak boleh negatif'),

--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -197,9 +197,13 @@ export default function RecordSalePage() {
                               placeholder="Jml"
                               min={1}
                               max={selectedItem?.stockQuantity}
-                              {...field}
+                              value={field.value ?? ''}
                               onChange={(e) => {
                                 const value = e.target.valueAsNumber;
+                                if (Number.isNaN(value)) {
+                                  field.onChange(undefined);
+                                  return;
+                                }
                                 if (value > maxStock) {
                                   alert(`Stok ${selectedItem?.name ?? ''} hanya tersisa ${selectedItem?.stockQuantity ?? 0}`);
                                   field.onChange(selectedItem?.stockQuantity);
@@ -221,7 +225,15 @@ export default function RecordSalePage() {
                       <FormItem className="col-span-8 md:col-span-4">
                         <FormLabel className="sr-only">Harga/Item</FormLabel>
                         <FormControl>
-                          <Input type="number" placeholder="Harga" {...field} />
+                          <Input
+                            type="number"
+                            placeholder="Harga"
+                            value={field.value ?? ''}
+                            onChange={(e) => {
+                              const value = e.target.valueAsNumber;
+                              field.onChange(Number.isNaN(value) ? undefined : value);
+                            }}
+                          />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -314,7 +326,14 @@ export default function RecordSalePage() {
                 <FormItem>
                   <FormLabel>{discountType === 'percent' ? 'Nilai Diskon (%)' : 'Nilai Diskon (Rp)'}</FormLabel>
                   <FormControl>
-                    <Input type="number" {...field} value={field.value ?? ''} />
+                    <Input
+                      type="number"
+                      value={field.value ?? ''}
+                      onChange={(e) => {
+                        const value = e.target.valueAsNumber;
+                        field.onChange(Number.isNaN(value) ? undefined : value);
+                      }}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -337,7 +356,14 @@ export default function RecordSalePage() {
                   <FormItem>
                     <FormLabel>Nominal Cash</FormLabel>
                     <FormControl>
-                      <Input type="number" {...field} value={field.value ?? ''} />
+                      <Input
+                        type="number"
+                        value={field.value ?? ''}
+                        onChange={(e) => {
+                          const value = e.target.valueAsNumber;
+                          field.onChange(Number.isNaN(value) ? undefined : value);
+                        }}
+                      />
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -205,7 +205,7 @@ export default function RecordSalePage() {
                                   return;
                                 }
                                 if (value > maxStock) {
-                                  alert(`Stok ${selectedItem?.name ?? ''} hanya tersisa ${selectedItem?.stockQuantity ?? 0}`);
+                                  toast({ description: `Stok ${selectedItem?.name ?? ''} hanya tersisa ${selectedItem?.stockQuantity ?? 0}`, variant: 'destructive', color: 'red' });
                                   field.onChange(selectedItem?.stockQuantity);
                                 } else {
                                   field.onChange(value);

--- a/src/components/ui/inventory-combobox.tsx
+++ b/src/components/ui/inventory-combobox.tsx
@@ -110,20 +110,22 @@ export function InventoryCombobox({ value, onSelect, isLoading = false }: Invent
                     </DialogTrigger>
                   </CommandEmpty>
                   <CommandGroup>
-                    {inventoryItems.map((item) => (
-                      <CommandItem
-                        key={item.id}
-                        value={item.name}
-                        onSelect={() => {
-                          onSelect({ name: item.name, price: item.sellingPrice });
-                          setOpen(false);
-                          setSearchQuery('');
-                        }}
-                      >
-                        <Check className={cn('mr-2 h-4 w-4', value === item.name ? 'opacity-100' : 'opacity-0')} />
-                        {item.name}
-                      </CommandItem>
-                    ))}
+                    {inventoryItems
+                      .filter((item) => item.stockQuantity > 0)
+                      .map((item) => (
+                        <CommandItem
+                          key={item.id}
+                          value={item.name}
+                          onSelect={() => {
+                            onSelect({ name: item.name, price: item.sellingPrice });
+                            setOpen(false);
+                            setSearchQuery('');
+                          }}
+                        >
+                          <Check className={cn('mr-2 h-4 w-4', value === item.name ? 'opacity-100' : 'opacity-0')} />
+                          {item.name}
+                        </CommandItem>
+                      ))}
                   </CommandGroup>
                 </>
               )}

--- a/src/components/ui/inventory-combobox.tsx
+++ b/src/components/ui/inventory-combobox.tsx
@@ -30,7 +30,10 @@ const newItemSchema = z.object({
   sellingPrice: z.coerce.number().min(0, 'Harga jual harus diisi'),
   purchasePrice: z.coerce.number().min(0, 'Harga beli harus diisi'),
   stockQuantity: z.coerce.number().int().min(0, 'Stok awal harus diisi'),
-  sku: z.string().optional(),
+  sku: z
+    .string()
+    .optional()
+    .transform((val) => (val && val.trim() !== '' ? val.trim() : undefined)),
 });
 type NewItemFormValues = z.infer<typeof newItemSchema>;
 

--- a/src/stores/inventory.store.ts
+++ b/src/stores/inventory.store.ts
@@ -4,6 +4,12 @@ import type { InventoryItem, NewInventoryItemInput, UpdateInventoryItemInput } f
 import type { PaginationState, SortingState } from '@tanstack/react-table';
 import type { DateRange } from 'react-day-picker';
 
+const generateSku = (name: string): string => {
+  const prefix = name.replace(/\s+/g, '').toUpperCase().slice(0, 3);
+  const random = Math.random().toString(36).substring(2, 8).toUpperCase();
+  return `${prefix}-${random}`;
+};
+
 interface InventoryState {
   inventoryItems: InventoryItem[];
   isLoading: boolean;
@@ -65,11 +71,12 @@ export const useInventoryStore = create<InventoryState>((set, get) => ({
 
   addInventoryItem: async (itemData) => {
     const supabase = createClient();
+    const sku = itemData.sku && itemData.sku.trim() !== '' ? itemData.sku.trim() : generateSku(itemData.name);
     const { data, error } = await supabase
       .from('inventory_items')
       .insert({
         name: itemData.name,
-        sku: itemData.sku,
+        sku,
         stock_quantity: itemData.stockQuantity,
         purchase_price: itemData.purchasePrice,
         selling_price: itemData.sellingPrice,


### PR DESCRIPTION
## Summary
- hide out-of-stock items from inventory combobox
- block sales that exceed available stock and alert current quantity

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689e72a7ea308329ab3bdd7c6765b4a7