### PR TITLE
feat: track service parts cost

### DIFF
--- a/src/app/admin/edit-transaction/[id]/page.tsx
+++ b/src/app/admin/edit-transaction/[id]/page.tsx
@@ -42,6 +42,7 @@ const serviceEditSchema = z.object({
     .refine((val) => !val || /^[0-9\s+-]+$/.test(val), { message: 'Invalid phone number format' }),
   customerAddress: z.string().optional(),
   serviceFee: z.coerce.number().min(0, 'Service fee must be non-negative'),
+  partsCost: z.coerce.number().min(0, 'Parts cost must be non-negative'),
 });
 
 const expenseEditSchema = z.object({
@@ -87,7 +88,7 @@ export default function EditTransactionPage() {
           if (tx.type === 'sale') {
             form.reset({ type: 'sale', customerName: tx.customerName || '', items: tx.items.map((item) => ({ ...item })) });
           } else if (tx.type === 'service') {
-            form.reset({ type: 'service', serviceName: tx.serviceName, customerName: tx.customerName || '', customerPhone: tx.customerPhone || '', customerAddress: tx.customerAddress || '', serviceFee: tx.serviceFee });
+            form.reset({ type: 'service', serviceName: tx.serviceName, customerName: tx.customerName || '', customerPhone: tx.customerPhone || '', customerAddress: tx.customerAddress || '', serviceFee: tx.serviceFee, partsCost: tx.partsCost || 0 });
           } else if (tx.type === 'expense') {
             form.reset({ type: 'expense', description: tx.description, category: tx.category || '', amount: tx.amount });
           }
@@ -112,7 +113,16 @@ export default function EditTransactionPage() {
       const grandTotal = itemsWithTotals.reduce((sum, i) => sum + i.total, 0);
       updatePayload = { customerName: saleData.customerName, details: { items: itemsWithTotals }, total_amount: grandTotal };
     } else if (data.type === 'service') {
-      updatePayload = { customerName: data.customerName, total_amount: data.serviceFee, details: { serviceName: data.serviceName, device: 'N/A', issueDescription: 'N/A' } };
+      updatePayload = {
+        customerName: data.customerName,
+        total_amount: data.serviceFee,
+        details: {
+          serviceName: data.serviceName,
+          device: 'N/A',
+          issueDescription: 'N/A',
+          partsCost: data.partsCost,
+        },
+      };
     } else if (data.type === 'expense') {
       updatePayload = {
         total_amount: data.amount,
@@ -332,6 +342,19 @@ export default function EditTransactionPage() {
                         <Input type="number" placeholder="150000" {...field} />
                       </FormControl>{' '}
                       <FormMessage />{' '}
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="partsCost"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Biaya Barang (IDR)</FormLabel>
+                      <FormControl>
+                        <Input type="number" placeholder="50000" {...field} />
+                      </FormControl>
+                      <FormMessage />
                     </FormItem>
                   )}
                 />

--- a/src/app/reports/hooks/useReports.ts
+++ b/src/app/reports/hooks/useReports.ts
@@ -34,7 +34,10 @@ export function useReports(transactions: Transaction[]) {
   const rangeRecap = useMemo(() => {
     return filteredTransactions.reduce((acc, tx) => {
       if (tx.type === 'sale') acc.totalSales += tx.grandTotal;
-      if (tx.type === 'service') acc.totalServices += tx.serviceFee;
+      if (tx.type === 'service') {
+        acc.totalServices += tx.serviceFee;
+        acc.totalExpenses += tx.partsCost || 0;
+      }
       if (tx.type === 'expense') acc.totalExpenses += tx.amount;
       return acc;
     }, { totalSales: 0, totalServices: 0, totalExpenses: 0 });
@@ -54,7 +57,10 @@ export function useReports(transactions: Transaction[]) {
       const monthlyTotals = transactions.reduce((acc, tx) => {
         if (format(parseISO(tx.date), 'yyyy-MM') === format(monthStart, 'yyyy-MM')) {
           if (tx.type === 'sale') acc.sales += tx.grandTotal;
-          if (tx.type === 'service') acc.services += tx.serviceFee;
+          if (tx.type === 'service') {
+            acc.services += tx.serviceFee;
+            acc.expenses += tx.partsCost || 0;
+          }
           if (tx.type === 'expense') acc.expenses += tx.amount;
         }
         return acc;
@@ -73,6 +79,10 @@ export function useReports(transactions: Transaction[]) {
       if (tx.type === 'expense') {
         const category = tx.category || 'Lain-lain';
         acc[category] = (acc[category] || 0) + tx.amount;
+      }
+      if (tx.type === 'service' && tx.partsCost) {
+        const category = 'Biaya Barang Servis';
+        acc[category] = (acc[category] || 0) + tx.partsCost;
       }
       return acc;
     }, {} as { [key: string]: number });

--- a/src/app/transactions/[id]/page.tsx
+++ b/src/app/transactions/[id]/page.tsx
@@ -235,6 +235,15 @@ function ServiceDetails({ tx, qrCodeUrl }: { tx: ServiceTransaction; qrCodeUrl: 
         <p className="text-lg font-bold">Biaya Servis</p>
         <p className="text-lg font-bold text-primary font-mono">{formatCurrency(tx.serviceFee)}</p>
       </div>
+      {(tx.partsCost ?? 0) > 0 && (
+        <>
+          <Separator />
+          <div className="flex justify-between items-center">
+            <p className="text-lg font-bold">Biaya Barang</p>
+            <p className="text-lg font-bold text-primary font-mono">{formatCurrency(tx.partsCost ?? 0)}</p>
+          </div>
+        </>
+      )}
       <Separator />
       {qrCodeUrl && (
         <div className="text-center">

--- a/src/stores/transaction.store.ts
+++ b/src/stores/transaction.store.ts
@@ -105,6 +105,7 @@ export const useTransactionStore = create<TransactionState>((set) => ({
           device: transactionData.device,
           issueDescription: transactionData.issueDescription,
           status: transactionData.status || 'PENDING_CONFIRMATION',
+          partsCost: transactionData.partsCost || 0,
           progressNotes: [],
         } as Json,
       };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -56,6 +56,7 @@ export type ServiceTransaction = {
   customerAddress?: string;
   customerId?: string; // Optional: to link to a specific customer in CRM
   serviceFee: number;
+  partsCost?: number; // Cost of parts or goods used for the service
   status: ServiceStatusValue;
   progressNotes: ProgressNote[];
 };

--- a/src/utils/mapDBRowToTransaction.ts
+++ b/src/utils/mapDBRowToTransaction.ts
@@ -35,6 +35,7 @@ export function mapDbRowToTransaction(tx: any): Transaction | null {
         device: details.device,
         issueDescription: details.issueDescription,
         status: details.status,
+        partsCost: details.partsCost ?? 0,
         progressNotes: details.progressNotes ?? [],
       } as ServiceTransaction;
 

--- a/src/utils/mapDBRowToTransaction.ts
+++ b/src/utils/mapDBRowToTransaction.ts
@@ -35,7 +35,10 @@ export function mapDbRowToTransaction(tx: any): Transaction | null {
         device: details.device,
         issueDescription: details.issueDescription,
         status: details.status,
-        partsCost: details.partsCost ?? 0,
+        partsCost:
+          typeof details.partsCost === 'string'
+            ? parseFloat(details.partsCost)
+            : (details.partsCost ?? 0),
         progressNotes: details.progressNotes ?? [],
       } as ServiceTransaction;
 


### PR DESCRIPTION
## Summary
- add parts cost tracking for service transactions
- include parts cost in reports profit and expense breakdown
- show parts cost in service transaction details and admin form

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689f3656719c832990b5166840605d4a