### PR TITLE
Allow duplicate customer phone numbers and prevent form submission on combobox

### DIFF
--- a/src/components/ui/customer-combobox.tsx
+++ b/src/components/ui/customer-combobox.tsx
@@ -68,6 +68,7 @@ export function CustomerCombobox({ value, onChange, isLoading = false }: Custome
       setDialogOpen(false);
       setOpen(false);
       form.reset();
+      form.clearErrors();
       setSearchQuery('');
     } else {
       toast({
@@ -84,7 +85,7 @@ export function CustomerCombobox({ value, onChange, isLoading = false }: Custome
     <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
-          <Button variant="outline" role="combobox" className="w-full justify-between font-normal">
+          <Button type="button" variant="outline" role="combobox" className="w-full justify-between font-normal">
             <div className="flex items-center truncate">
               <UserCircle className="mr-2 h-4 w-4 text-muted-foreground flex-shrink-0" />
               <span className="truncate">{selectedCustomerName || 'Pilih atau tambah pelanggan...'}</span>
@@ -104,7 +105,7 @@ export function CustomerCombobox({ value, onChange, isLoading = false }: Custome
                 <>
                   <CommandEmpty className="p-1">
                     <DialogTrigger asChild>
-                      <Button variant="ghost" className="w-full justify-start text-left h-auto py-2">
+                      <Button type="button" variant="ghost" className="w-full justify-start text-left h-auto py-2">
                         <PlusCircle className="mr-2 h-4 w-4" />
                         <div>
                           <p>Tambah Pelanggan Baru </p>

--- a/src/stores/customer.store.ts
+++ b/src/stores/customer.store.ts
@@ -58,13 +58,6 @@ export const useCustomerStore = create<CustomerState>((set, get) => ({
 
   addCustomer: async (customerData) => {
     const supabase = createClient();
-    if (customerData.phone) {
-      const { data: existing } = await supabase.from('customers').select('id').eq('phone', customerData.phone).single();
-      if (existing) {
-        return { customer: null, error: new Error('Nomor telepon sudah digunakan pelanggan lain.') };
-      }
-    }
-
     const { data: newCustomerData, error } = await supabase.from('customers').insert(customerData).select().single();
 
     if (error) {
@@ -82,6 +75,7 @@ export const useCustomerStore = create<CustomerState>((set, get) => ({
       updatedAt: newCustomerData.updated_at,
     };
 
+    set((state) => ({ customers: [...state.customers, formattedCustomer] }));
     return { customer: formattedCustomer, error: null };
   },
 


### PR DESCRIPTION
## Summary
- allow creating customers with duplicate phone numbers
- avoid accidental form submissions when interacting with CustomerCombobox and clear validation errors after adding new customer

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a42daae77483299aff5cfc3b9c48f3