### PR TITLE
Translate service status options and add failure states

### DIFF
--- a/src/app/admin/service-management/[id]/page.tsx
+++ b/src/app/admin/service-management/[id]/page.tsx
@@ -97,7 +97,7 @@ export default function ManageServiceProgressPage() {
   
   const getStatusIcon = (status: ServiceTransaction['status']) => {
     if (status.startsWith('COMPLETED')) return <CheckCircle className="h-5 w-5 text-green-500" />;
-    if (status === 'CANCELLED') return <CircleSlash className="h-5 w-5 text-red-500" />;
+    if (['CANCELLED', 'PARTS_UNAVAILABLE', 'UNABLE_TO_REPAIR'].includes(status)) return <CircleSlash className="h-5 w-5 text-red-500" />;
     if (['AWAITING_PARTS', 'DIAGNOSIS_IN_PROGRESS', 'REPAIR_IN_PROGRESS'].includes(status)) return <Clock className="h-5 w-5 text-yellow-500" />;
     return <CheckCircle className="h-5 w-5 text-blue-500" />;
   };

--- a/src/app/service-status/[id]/page.tsx
+++ b/src/app/service-status/[id]/page.tsx
@@ -57,7 +57,7 @@ console.log({isLoading})
 
   const getStatusIcon = (status: ServiceTransaction['status']) => {
     if (status.startsWith('COMPLETED')) return <CheckCircle className="h-6 w-6 text-green-500" />;
-    if (status === 'CANCELLED') return <CircleSlash className="h-6 w-6 text-red-500" />;
+    if (['CANCELLED', 'PARTS_UNAVAILABLE', 'UNABLE_TO_REPAIR'].includes(status)) return <CircleSlash className="h-6 w-6 text-red-500" />;
     if (['AWAITING_PARTS', 'IN_DIAGNOSIS', 'IN_REPAIR_QUEUE', 'REPAIR_IN_PROGRESS'].includes(status)) return <Clock className="h-6 w-6 text-yellow-500" />;
     return <Info className="h-6 w-6 text-blue-500" />;
   };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,16 +24,18 @@ export type SaleTransaction = {
 };
 
 export const ServiceStatusOptions = [
-  { value: 'PENDING_CONFIRMATION', label: 'Pending Confirmation' },
-  { value: 'CONFIRMED_QUEUED', label: 'Confirmed & Queued' },
-  { value: 'TECHNICIAN_ASSIGNED', label: 'Technician Assigned' },
-  { value: 'DIAGNOSIS_IN_PROGRESS', label: 'Diagnosis in Progress' },
-  { value: 'AWAITING_PARTS', label: 'Awaiting Parts' },
-  { value: 'REPAIR_IN_PROGRESS', label: 'Repair in Progress' },
-  { value: 'QUALITY_CHECK', label: 'Quality Check' },
-  { value: 'READY_FOR_PICKUP', label: 'Ready for Pickup' },
-  { value: 'COMPLETED_COLLECTED', label: 'Completed & Collected' },
-  { value: 'CANCELLED', label: 'Cancelled' },
+  { value: 'PENDING_CONFIRMATION', label: 'Menunggu Konfirmasi' },
+  { value: 'CONFIRMED_QUEUED', label: 'Terkonfirmasi & Dalam Antrian' },
+  { value: 'TECHNICIAN_ASSIGNED', label: 'Teknisi Ditugaskan' },
+  { value: 'DIAGNOSIS_IN_PROGRESS', label: 'Diagnosa Sedang Dilakukan' },
+  { value: 'AWAITING_PARTS', label: 'Menunggu Sparepart' },
+  { value: 'PARTS_UNAVAILABLE', label: 'Sparepart Kosong' },
+  { value: 'REPAIR_IN_PROGRESS', label: 'Perbaikan Sedang Berlangsung' },
+  { value: 'QUALITY_CHECK', label: 'Pemeriksaan Kualitas' },
+  { value: 'READY_FOR_PICKUP', label: 'Siap Diambil' },
+  { value: 'COMPLETED_COLLECTED', label: 'Selesai & Diambil' },
+  { value: 'UNABLE_TO_REPAIR', label: 'Tidak Bisa Diperbaiki' },
+  { value: 'CANCELLED', label: 'Dibatalkan' },
 ] as const;
 
 export type ServiceStatusValue = (typeof ServiceStatusOptions)[number]['value'];


### PR DESCRIPTION
## Summary
- localize service status labels into Indonesian
- add spare part unavailable and unable to repair status options
- show cancel icon for the new failure statuses

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a6a87e50a483299de8ec47b15f505c