### PR TITLE
feat: improve transactions access and tooling

### DIFF
--- a/src/app/transactions/[id]/page.tsx
+++ b/src/app/transactions/[id]/page.tsx
@@ -18,7 +18,9 @@ import type { StoreSettings, Transaction, SaleTransaction, ServiceTransaction, E
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
-import { ArrowLeft, Printer, Settings, Building, Loader2 } from 'lucide-react';
+import { ArrowLeft, Printer, Settings, Building, Loader2, MessageCircle } from 'lucide-react';
+import { useAuthStore } from '@/stores/auth.store';
+import { toWhatsAppLink } from '@/utils/whatsapp';
 
 // Helper Function
 const formatCurrency = (amount: number): string => {
@@ -284,6 +286,8 @@ function ExpenseDetails({ tx }: { tx: ExpenseTransaction }) {
 
 function ReceiptFooter({ transaction, onPrintClick, isPrinting }: { transaction: Transaction; onPrintClick: () => void; isPrinting: boolean }) {
   const router = useRouter();
+  const currentUser = useAuthStore((s) => s.user);
+  const phone = transaction.type === 'service' ? (transaction as ServiceTransaction).customerPhone : undefined;
 
   return (
     <CardContent className="p-6">
@@ -292,7 +296,14 @@ function ReceiptFooter({ transaction, onPrintClick, isPrinting }: { transaction:
           <ArrowLeft className="mr-2 h-4 w-4" /> Kembali
         </Button>
         <div className="flex gap-2 w-full sm:w-auto">
-          {transaction.type === 'service' && (
+          {transaction.type === 'service' && phone && (
+            <Button asChild variant="outline" className="flex-1">
+              <Link href={toWhatsAppLink(phone)} target="_blank">
+                <MessageCircle className="mr-1 h-4 w-4" /> Chat
+              </Link>
+            </Button>
+          )}
+          {transaction.type === 'service' && currentUser?.role === 'admin' && (
             <Button asChild variant="outline" className="flex-1">
               <Link href={`/admin/service-management/${transaction.id}`}>
                 <Settings className="mr-1 h-4 w-4" /> Kelola

--- a/src/app/transactions/actions.ts
+++ b/src/app/transactions/actions.ts
@@ -30,7 +30,12 @@ export async function getPaginatedTransactions({
 
     if (sorting.length > 0) {
       const sort = sorting[0];
-      query = query.order(sort.id, { ascending: !sort.desc });
+      const column = sort.id === 'date'
+        ? 'created_at'
+        : sort.id === 'amount'
+          ? 'total_amount'
+          : sort.id;
+      query = query.order(column, { ascending: !sort.desc });
     } else {
       query = query.order('created_at', { ascending: false });
     }
@@ -40,7 +45,7 @@ export async function getPaginatedTransactions({
     if (error) throw error;
 
     const formattedTransactions = data.map(mapDbRowToTransaction).filter(Boolean) as Transaction[];
-    const pageCount = Math.ceil((count ?? 0) / pageSize);
+    const pageCount = Math.max(1, Math.ceil((count ?? 0) / pageSize));
 
     return { data: formattedTransactions, error: null, pageCount };
   } catch (error) {

--- a/src/app/transactions/transactions-table.tsx
+++ b/src/app/transactions/transactions-table.tsx
@@ -1,15 +1,18 @@
 'use client';
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import Link from 'next/link';
-// import { useTransactions } from '@/context/transaction-context';
-import type { Transaction } from '@/types';
+import type { Transaction, TransactionTypeFilter, ServiceTransaction } from '@/types';
 import { DataTable, createSortableHeader } from '@/components/ui/data-table';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Eye, Settings } from 'lucide-react';
+import { Eye, Settings, MessageCircle } from 'lucide-react';
 import type { ColumnDef } from '@tanstack/react-table';
 import { useTransactionStore } from '@/stores/transaction.store';
+import { useAuthStore } from '@/stores/auth.store';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { toWhatsAppLink } from '@/utils/whatsapp';
 
 // Helper functions (can be moved to a utils file if needed)
 const formatCurrency = (amount: number) => {
@@ -30,84 +33,98 @@ const getTransactionAmount = (tx: Transaction) => {
   return 0;
 };
 
-// Column Definitions
-const columns: ColumnDef<Transaction>[] = [
-  {
-    accessorKey: 'date',
-    header: ({ column }) => createSortableHeader(column, 'Date'),
-    cell: ({ row }) => new Date(row.original.date).toLocaleDateString('id-ID'),
-  },
-  {
-    accessorKey: 'type',
-    header: 'Type',
-    cell: ({ row }) => {
-      const tx = row.original;
-      return (
-        <Badge variant={tx.type === 'expense' ? 'destructive' : tx.type === 'sale' ? 'default' : 'secondary'} className="capitalize">
-          {tx.type}
-        </Badge>
-      );
-    },
-  },
-  {
-    id: 'description',
-    header: 'Description',
-    cell: ({ row }) => getTransactionSummary(row.original),
-  },
-  {
-    id: 'amount',
-    header: ({ column }) => createSortableHeader(column, 'Amount (IDR)'),
-    cell: ({ row }) => {
-      const tx = row.original;
-      const amount = getTransactionAmount(tx);
-      return (
-        <div className={`text-right font-medium ${tx.type === 'expense' ? 'text-destructive' : 'text-green-600'}`}>
-          {tx.type === 'expense' ? '-' : '+'}
-          {formatCurrency(amount)}
-        </div>
-      );
-    },
-  },
-  {
-    id: 'actions',
-    header: 'Actions',
-    cell: ({ row }) => {
-      const tx = row.original;
-      return (
-        <div className="text-right space-x-2">
-          <Button asChild variant="outline" size="sm">
-            <Link href={`/transactions/${tx.id}`}>
-              <Eye className="mr-1 h-4 w-4" /> View
-            </Link>
-          </Button>
-          {tx.type === 'service' && (
-            <Button asChild variant="outline" size="sm">
-              <Link href={`/admin/service-management/${tx.id}`}>
-                <Settings className="mr-1 h-4 w-4" /> Manage
-              </Link>
-            </Button>
-          )}
-        </div>
-      );
-    },
-  },
-];
-
 interface TransactionsTableProps {
   initialData: Transaction[];
   initialPageCount: number;
 }
 
 export function TransactionsTable({ initialData, initialPageCount }: TransactionsTableProps) {
-  const { transactions, isLoading, pageCount, fetchData } = useTransactionStore();
+  const { transactions, isLoading, pageCount: storePageCount, fetchData } = useTransactionStore();
+  const currentUser = useAuthStore((s) => s.user);
 
-  // Use context data if available, otherwise fall back to initial props
+  // filter states
+  const [search, setSearch] = useState('');
+  const [typeFilter, setTypeFilter] = useState<TransactionTypeFilter>('all');
+
+  // Data from store or initial
   const data = transactions.length > 0 ? transactions : initialData;
-  const count = pageCount > 0 ? pageCount : initialPageCount;
+  const count = storePageCount > 0 ? storePageCount : initialPageCount;
 
-  // Memoize the filters object to prevent re-creating it on every render,
-  // which would cause an infinite loop in the DataTable's useEffect hook.
-  const filters = useMemo(() => ({}), []);
+  // Filters passed to table fetcher
+  const filters = useMemo(() => ({
+    customerName: search || undefined,
+    type: typeFilter,
+  }), [search, typeFilter]);
+
+  const columns = useMemo<ColumnDef<Transaction>[]>(() => [
+    {
+      accessorKey: 'date',
+      header: ({ column }) => createSortableHeader(column, 'Date'),
+      cell: ({ row }) => new Date(row.original.date).toLocaleDateString('id-ID'),
+    },
+    {
+      accessorKey: 'type',
+      header: 'Type',
+      cell: ({ row }) => {
+        const tx = row.original;
+        return (
+          <Badge variant={tx.type === 'expense' ? 'destructive' : tx.type === 'sale' ? 'default' : 'secondary'} className="capitalize">
+            {tx.type}
+          </Badge>
+        );
+      },
+    },
+    {
+      id: 'description',
+      header: 'Description',
+      cell: ({ row }) => getTransactionSummary(row.original),
+    },
+    {
+      id: 'amount',
+      header: ({ column }) => createSortableHeader(column, 'Amount (IDR)'),
+      cell: ({ row }) => {
+        const tx = row.original;
+        const amount = getTransactionAmount(tx);
+        return (
+          <div className={`text-right font-medium ${tx.type === 'expense' ? 'text-destructive' : 'text-green-600'}`}>
+            {tx.type === 'expense' ? '-' : '+'}
+            {formatCurrency(amount)}
+          </div>
+        );
+      },
+    },
+    {
+      id: 'actions',
+      header: 'Actions',
+      cell: ({ row }) => {
+        const tx = row.original;
+        const phone = tx.type === 'service' ? (tx as ServiceTransaction).customerPhone : undefined;
+        return (
+          <div className="text-right space-x-2">
+            <Button asChild variant="outline" size="sm">
+              <Link href={`/transactions/${tx.id}`}>
+                <Eye className="mr-1 h-4 w-4" /> View
+              </Link>
+            </Button>
+            {tx.type === 'service' && phone && (
+              <Button asChild variant="outline" size="sm">
+                <Link href={toWhatsAppLink(phone)} target="_blank">
+                  <MessageCircle className="mr-1 h-4 w-4" /> Chat
+                </Link>
+              </Button>
+            )}
+            {tx.type === 'service' && currentUser?.role === 'admin' && (
+              <Button asChild variant="outline" size="sm">
+                <Link href={`/admin/service-management/${tx.id}`}>
+                  <Settings className="mr-1 h-4 w-4" /> Manage
+                </Link>
+              </Button>
+            )}
+          </div>
+        );
+      },
+    },
+  ], [currentUser]);
 
   return (
     <DataTable
@@ -117,7 +134,27 @@ export function TransactionsTable({ initialData, initialPageCount }: Transaction
       fetchData={fetchData}
       isLoading={isLoading}
       filters={filters}
-      refreshTrigger={0} // Placeholder
-    />
+      refreshTrigger={0}
+    >
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <Input
+          placeholder="Cari pelanggan..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="w-full sm:max-w-xs"
+        />
+        <Select value={typeFilter} onValueChange={(v) => setTypeFilter(v as TransactionTypeFilter)}>
+          <SelectTrigger className="w-full sm:w-[180px]">
+            <SelectValue placeholder="Semua tipe" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Semua</SelectItem>
+            <SelectItem value="sale">Penjualan</SelectItem>
+            <SelectItem value="service">Servis</SelectItem>
+            <SelectItem value="expense">Pengeluaran</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+    </DataTable>
   );
 }

--- a/src/stores/transaction.store.ts
+++ b/src/stores/transaction.store.ts
@@ -53,7 +53,12 @@ export const useTransactionStore = create<TransactionState>((set) => ({
     if (filters.type && filters.type !== 'all') query = query.eq('type', filters.type);
     if (sorting.length > 0) {
         const sort = sorting[0];
-        query = query.order(sort.id, { ascending: !sort.desc });
+        const column = sort.id === 'date'
+          ? 'created_at'
+          : sort.id === 'amount'
+            ? 'total_amount'
+            : sort.id;
+        query = query.order(column, { ascending: !sort.desc });
     } else {
         query = query.order('created_at', { ascending: false });
     }
@@ -66,7 +71,7 @@ export const useTransactionStore = create<TransactionState>((set) => ({
     }
 
     const formattedTransactions = data?.map(mapDbRowToTransaction).filter(Boolean) as Transaction[] || [];
-    set({ transactions: formattedTransactions, pageCount: Math.ceil((count ?? 0) / pageSize), isLoading: false });
+    set({ transactions: formattedTransactions, pageCount: Math.max(1, Math.ceil((count ?? 0) / pageSize)), isLoading: false });
     return { error: null };
   },
 

--- a/src/utils/mapDBRowToTransaction.ts
+++ b/src/utils/mapDBRowToTransaction.ts
@@ -40,6 +40,8 @@ export function mapDbRowToTransaction(tx: any): Transaction | null {
             ? parseFloat(details.partsCost)
             : (details.partsCost ?? 0),
         progressNotes: details.progressNotes ?? [],
+        customerPhone: tx.customer_phone || details.customerPhone,
+        customerAddress: tx.customer_address || details.customerAddress,
       } as ServiceTransaction;
 
     case 'expense':

--- a/src/utils/whatsapp.ts
+++ b/src/utils/whatsapp.ts
@@ -1,0 +1,9 @@
+export function toWhatsAppLink(phone: string): string {
+  let cleaned = phone.replace(/\D/g, '');
+  if (cleaned.startsWith('0')) {
+    cleaned = '62' + cleaned.slice(1);
+  } else if (!cleaned.startsWith('62')) {
+    cleaned = '62' + cleaned;
+  }
+  return `https://wa.me/${cleaned}`;
+}


### PR DESCRIPTION
## Summary
- add admin role checks for manage buttons on transactions pages
- support WhatsApp chat links when customer phone is available
- implement search, filter, sorting and better pagination for transactions

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a6da38fe5483299255f0a9f6a0b383